### PR TITLE
add support for unsigned kernel images

### DIFF
--- a/KernelUpdateScriptGenerator
+++ b/KernelUpdateScriptGenerator
@@ -220,12 +220,23 @@ if [ "$action" == "y" ];then
 	fi
 fi
 # If I don't need the header package do I need the image-extra package?
-if [ $NoHeader -eq 1 ];then
-	wget -nc $WHERE/linux-{image-extra,image}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
+# amd64 kernels are now signed
+if [ "$arch" == "amd64" ]; then
+	if [ $NoHeader -eq 1 ]; then
+		wget -nc $WHERE/linux-{image-unsigned,modules}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
+	else
+		wget -nc $WHERE/linux-headers-$VER_A"_$VER_A"."$VER_B"_all.deb
+		wget -nc $WHERE/linux-{image-unsigned,modules,headers}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
+	fi
 else
-	wget -nc $WHERE/linux-headers-$VER_A"_$VER_A"."$VER_B"_all.deb
-	wget -nc $WHERE/linux-{image-extra,headers,image}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
+	if [ $NoHeader -eq 1 ];then
+		wget -nc $WHERE/linux-{image-extra,image}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
+	else
+		wget -nc $WHERE/linux-headers-$VER_A"_$VER_A"."$VER_B"_all.deb
+		wget -nc $WHERE/linux-{image-extra,headers,image}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
+	fi
 fi
+
 clear
 total=$(ls linux-*.deb | wc -l)
 if [ $NoHeader -eq 1 ];then

--- a/KernelUpdateScriptGenerator
+++ b/KernelUpdateScriptGenerator
@@ -220,8 +220,8 @@ if [ "$action" == "y" ];then
 	fi
 fi
 # If I don't need the header package do I need the image-extra package?
-# amd64 kernels are now signed
-if [ "$arch" == "amd64" ]; then
+# amd64 kernels are signed as of 4.17-rc2, 201804152230 is the dt for 4.17-rc1
+if [[ "$arch" == "amd64" && ($VER_B -gt 201804152230) ]]; then
 	if [ $NoHeader -eq 1 ]; then
 		wget -nc $WHERE/linux-{image-unsigned,modules}-$VER_A-<?php echo ($l?'lowlatency':'generic'); ?>_$VER_A."$VER_B"_$arch.deb
 	else


### PR DESCRIPTION
The Ubuntu Kernel team has changed default naming to linux-image-unsigned (denoting unsigned kernels) from the old denoting of signed images as linux-signed-image. All rc builds are obviously not endorsed by Canonical Ltd and therefore are not signed as official images. This requires some change to the names of the deb archives the KernelUpdateScriptGenerator places in the generated install script.

For now this only seems to impact amd64 and ppc64el, but ppc64el support isn't complete yet and I have no way to test it. This changes the fetch names only for amd64 architectures on kernels after 4.17-rc1 where this change first appears in rc2. This is done with a datetime check denoted by VER_B in the script.

[Ask Ubuntu Thread](https://askubuntu.com/questions/1036216/why-are-linux-kernel-images-missing-from-the-ubuntu-kernel-ppa-for-4-17-rcx-ub)
[Ubuntu Kernel Team Mail Thread (sortof)](https://lists.ubuntu.com/archives/kernel-team/2018-May/092197.html)